### PR TITLE
sphinxcontrib-qthelp 2.0.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
 
+channels:
+- https://staging.continuum.io/prefect/fs/sphinx-feedstock/pr18/cfc3614

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
-
-channels:
-- https://staging.continuum.io/prefect/fs/sphinx-feedstock/pr18/cfc3614

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,15 +12,15 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
-  skip: true  # [py<39]
+  noarch: python
 
 requirements:
   host:
-    - python
+    - python >=3.9
     - pip
     - flit-core >=3.7
   run:
-    - python
+    - python >=3.9
     - sphinx >=5
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,12 +16,11 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python 3.9
     - pip
     - flit-core >=3.7
   run:
-    - python >=3.9
-    - sphinx >=5
+    - python 3.9
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,24 +1,27 @@
-{% set version = "1.0.3" %}
+{% set name = "sphinxcontrib-qthelp" %}
+{% set version = "2.0.0" %}
 
 package:
   name: sphinxcontrib-qthelp
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/s/sphinxcontrib-qthelp/sphinxcontrib-qthelp-{{ version }}.tar.gz
-  sha256: 4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72
+  url: https://pypi.org/packages/source/s/sphinxcontrib-qthelp/sphinxcontrib_qthelp-{{ version }}.tar.gz
+  sha256: 4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
+  skip: true  # [py<39]
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pip
+    - flit-core >=3.7
   run:
-    - python >=3.5
+    - python
+    - sphinx >=5
 
 test:
   requires:
@@ -32,11 +35,13 @@ test:
     - sphinxcontrib.qthelp
 
 about:
-  home: http://sphinx-doc.org/
+  home: https://www.sphinx-doc.org/
   license: BSD-2-Clause
   license_family: BSD
-  license_file: LICENSE
+  license_file: LICENCE.rst
   summary: sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document
+  doc_url: https://www.sphinx-doc.org/en/master/
+  dev_url: https://github.com/sphinx-doc/sphinxcontrib-qthelp
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
sphinxcontrib-qthelp 2.0.0 

**Destination channel:** Defaults

### Links

- [PKG-7691]
- dev_url:        https://github.com/sphinx-doc/sphinxcontrib-qthelp//tree/2.0.0
- conda_forge:    https://github.com/conda-forge/sphinxcontrib-qthelp-feedstock
- pypi:           https://pypi.org/project/sphinxcontrib-qthelp/2.0.0
- pypi inspector: https://inspector.pypi.io/project/sphinxcontrib-qthelp/2.0.0
- Required for:
    - https://github.com/AnacondaRecipes/sphinx-feedstock/pull/18

### Explanation of changes:

- new version number
- keeping noarch due to test circular dependencies with sphinx


[PKG-7691]: https://anaconda.atlassian.net/browse/PKG-7691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ