### PR TITLE
sphinxcontrib-qthelp 2.0.0 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
   noarch: python
 
@@ -20,13 +20,13 @@ requirements:
     - pip
     - flit-core >=3.7
   run:
-    - python 3.9
+    - python >=3.9
 
 test:
   requires:
     - pip
     # This is a circular dependency b/c sphinx depends on this package now :-/
-    - sphinx >=2
+    - sphinx >=5
   commands:
     - pip check
   imports:


### PR DESCRIPTION
sphinxcontrib-qthelp 2.0.0 rebuild

**Destination channel:** Defaults

### Links

- [PKG-7691]
- dev_url:        https://github.com/sphinx-doc/sphinxcontrib-qthelp//tree/2.0.0
- conda_forge:    https://github.com/conda-forge/sphinxcontrib-qthelp-feedstock
- pypi:           https://pypi.org/project/sphinxcontrib-qthelp/2.0.0
- pypi inspector: https://inspector.pypi.io/project/sphinxcontrib-qthelp/2.0.0
- Required for:
    - https://github.com/AnacondaRecipes/sphinx-feedstock/pull/18

### Explanation of changes:

- rebuild to fix python pinning

[PKG-7691]: https://anaconda.atlassian.net/browse/PKG-7691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ